### PR TITLE
Update domain registrar from Squarespace to Cloudflare

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### Basics
 
-**www-e2m2** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Netlify](https://netlify.com) with a domain registered via [Squarespace](https://domains.squarespace.com).
+**www-e2m2** is a [Jekyll](https://jekyllrb.com/)-generated static site. The published site is deployed using [Netlify](https://netlify.com) with a domain registered via [Cloudflare](https://www.cloudflare.com).
 
 [![Netlify Status](https://api.netlify.com/api/v1/badges/6115606f-755e-4d93-8662-a7bb0d56d742/deploy-status)](https://app.netlify.com/sites/e2m2/deploys)
 


### PR DESCRIPTION
## Summary
Updated the README to reflect a change in domain registrar for the www-e2m2 project.

## Changes
- Updated the domain registrar reference from Squarespace to Cloudflare in the project documentation
- This change documents the infrastructure update where the domain is now managed through Cloudflare instead of Squarespace Domains

## Details
The README's "Basics" section now accurately reflects that the domain for the deployed Netlify site is registered and managed via Cloudflare rather than Squarespace.

https://claude.ai/code/session_01A6VX2ADhsfBYsLDZxuDZnN